### PR TITLE
dash detekt: set maxIssues to -1

### DIFF
--- a/omnipod-dash/detekt-config.yml
+++ b/omnipod-dash/detekt-config.yml
@@ -1,5 +1,5 @@
 build:
-  maxIssues: 0
+  maxIssues: -1
   excludeCorrectable: false
   weights:
   # complexity: 2


### PR DESCRIPTION
I noticed that with this setting I canrun detekt from android-studio and
see all the issues reported in the Build Output.

Without it, I can only see: "Build failed with X issues."
