### PR TITLE
add connection quality and delivery status

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,27 +3,10 @@
     <option name="AUTODETECT_INDENTS" value="false" />
     <option name="WRAP_WHEN_TYPING_REACHES_RIGHT_MARGIN" value="true" />
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="java.util" alias="false" withSubpackages="false" />
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-          <package name="io.ktor" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
-        </value>
-      </option>
       <option name="ALIGN_IN_COLUMNS_CASE_BRANCH" value="true" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="6" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="6" />
       <option name="BLANK_LINES_AROUND_BLOCK_WHEN_BRANCHES" value="1" />
-      <option name="WRAP_EXPRESSION_BODY_FUNCTIONS" value="1" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="JAVA">
@@ -143,8 +126,8 @@
       </arrangement>
     </codeStyleSettings>
     <codeStyleSettings language="kotlin">
-      <option name="RIGHT_MARGIN" value="120" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+      <option name="RIGHT_MARGIN" value="120" />
       <option name="LINE_COMMENT_AT_FIRST_COLUMN" value="false" />
       <option name="LINE_COMMENT_ADD_SPACE" value="true" />
       <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
@@ -152,13 +135,6 @@
       <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
       <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
       <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
-      <option name="CALL_PARAMETERS_WRAP" value="5" />
-      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_WRAP" value="5" />
-      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
       <option name="ASSIGNMENT_WRAP" value="5" />
       <option name="METHOD_ANNOTATION_WRAP" value="5" />
       <option name="CLASS_ANNOTATION_WRAP" value="1" />

--- a/app/src/main/java/info/nightscout/androidaps/dependencyInjection/AppModule.kt
+++ b/app/src/main/java/info/nightscout/androidaps/dependencyInjection/AppModule.kt
@@ -15,6 +15,7 @@ import info.nightscout.androidaps.plugins.configBuilder.ConfigBuilderPlugin
 import info.nightscout.androidaps.plugins.configBuilder.PluginStore
 import info.nightscout.androidaps.plugins.configBuilder.ProfileFunctionImplementation
 import info.nightscout.androidaps.plugins.general.maintenance.ImportExportPrefsImpl
+import info.nightscout.androidaps.plugins.general.maintenance.PrefFileListProvider
 import info.nightscout.androidaps.plugins.general.nsclient.DataSyncSelectorImplementation
 import info.nightscout.androidaps.plugins.general.smsCommunicator.SmsCommunicatorPlugin
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.IobCobCalculatorPlugin
@@ -22,6 +23,8 @@ import info.nightscout.androidaps.plugins.pump.PumpSyncImplementation
 import info.nightscout.androidaps.queue.CommandQueue
 import info.nightscout.androidaps.utils.DateUtil
 import info.nightscout.androidaps.utils.androidNotification.NotificationHolderImpl
+import info.nightscout.androidaps.utils.buildHelper.BuildHelper
+import info.nightscout.androidaps.utils.buildHelper.BuildHelperImpl
 import info.nightscout.androidaps.utils.buildHelper.ConfigImpl
 import info.nightscout.androidaps.utils.resources.IconsProviderImplementation
 import info.nightscout.androidaps.utils.resources.ResourceHelper
@@ -55,6 +58,10 @@ open class AppModule {
     @Provides
     @Singleton
     fun provideStorage(): Storage = FileStorage()
+
+    @Provides
+    @Singleton
+    fun provideBuildHelper(config: Config, fileListProvider: PrefFileListProvider): BuildHelper = BuildHelperImpl(config, fileListProvider)
 
     @Provides
     @Singleton

--- a/app/src/main/java/info/nightscout/androidaps/utils/buildHelper/BuildHelperImpl.kt
+++ b/app/src/main/java/info/nightscout/androidaps/utils/buildHelper/BuildHelperImpl.kt
@@ -4,14 +4,11 @@ import info.nightscout.androidaps.BuildConfig
 import info.nightscout.androidaps.interfaces.Config
 import info.nightscout.androidaps.plugins.general.maintenance.PrefFileListProvider
 import java.io.File
-import javax.inject.Inject
-import javax.inject.Singleton
 
-@Singleton
-class BuildHelper @Inject constructor(
+class BuildHelperImpl constructor(
     private val config: Config,
     fileListProvider: PrefFileListProvider
-) {
+) : BuildHelper {
 
     private var devBranch = false
     private var engineeringMode = false
@@ -23,11 +20,10 @@ class BuildHelper @Inject constructor(
         devBranch = BuildConfig.VERSION.contains("-") || BuildConfig.VERSION.matches(Regex(".*[a-zA-Z]+.*"))
     }
 
-    fun isEngineeringModeOrRelease(): Boolean =
+    override fun isEngineeringModeOrRelease(): Boolean =
         if (!config.APS) true else engineeringMode || !devBranch
 
-    fun isEngineeringMode(): Boolean =
-        engineeringMode
+    override fun isEngineeringMode(): Boolean = engineeringMode
 
-    fun isDev(): Boolean = devBranch
+    override fun isDev(): Boolean = devBranch
 }

--- a/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/interfaces/ConstraintsCheckerTest.kt
@@ -19,7 +19,6 @@ import info.nightscout.androidaps.plugins.configBuilder.ConstraintChecker
 import info.nightscout.androidaps.plugins.constraints.objectives.ObjectivesPlugin
 import info.nightscout.androidaps.plugins.constraints.objectives.objectives.Objective
 import info.nightscout.androidaps.plugins.constraints.safety.SafetyPlugin
-import info.nightscout.androidaps.plugins.general.maintenance.LoggerUtils
 import info.nightscout.androidaps.plugins.general.maintenance.PrefFileListProvider
 import info.nightscout.androidaps.plugins.iob.iobCobCalculator.GlucoseStatusProvider
 import info.nightscout.androidaps.plugins.pump.combo.ComboPlugin

--- a/app/src/test/java/info/nightscout/androidaps/queue/QueueThreadTest.kt
+++ b/app/src/test/java/info/nightscout/androidaps/queue/QueueThreadTest.kt
@@ -12,7 +12,6 @@ import info.nightscout.androidaps.interfaces.Constraint
 import info.nightscout.androidaps.interfaces.PumpDescription
 import info.nightscout.androidaps.interfaces.PumpSync
 import info.nightscout.androidaps.plugins.configBuilder.ConstraintChecker
-import info.nightscout.androidaps.plugins.general.maintenance.LoggerUtils
 import info.nightscout.androidaps.plugins.general.maintenance.PrefFileListProvider
 import info.nightscout.androidaps.plugins.pump.virtual.VirtualPumpPlugin
 import info.nightscout.androidaps.queue.commands.Command

--- a/core/src/main/java/info/nightscout/androidaps/utils/buildHelper/BuildHelper.kt
+++ b/core/src/main/java/info/nightscout/androidaps/utils/buildHelper/BuildHelper.kt
@@ -1,0 +1,8 @@
+package info.nightscout.androidaps.utils.buildHelper
+
+interface BuildHelper {
+
+    fun isEngineeringModeOrRelease(): Boolean
+    fun isEngineeringMode(): Boolean
+    fun isDev(): Boolean
+}

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/OmnipodDashBleManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/OmnipodDashBleManagerImpl.kt
@@ -166,7 +166,7 @@ class OmnipodDashBleManagerImpl @Inject constructor(
                 throw SessionEstablishmentException("Received resynchronization SQN for the second time")
             }
         }
-
+        podState.successfulConnections++
         podState.commitEapAkaSequenceNumber()
     }
 
@@ -223,6 +223,7 @@ class OmnipodDashBleManagerImpl @Inject constructor(
             }
             emitter.onNext(PodEvent.EstablishingSession)
             establishSession(pairResult.msgSeq)
+            podState.successfulConnections++
             emitter.onNext(PodEvent.Connected)
             emitter.onComplete()
         } catch (ex: Exception) {

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/callbacks/BleCommCallbacks.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/callbacks/BleCommCallbacks.kt
@@ -211,8 +211,8 @@ class BleCommCallbacks(
 
     fun resetConnection() {
         aapsLogger.debug(LTag.PUMPBTCOMM, "Reset connection")
-        connected?.countDown()
-        serviceDiscoveryComplete?.countDown()
+        connected.countDown()
+        serviceDiscoveryComplete.countDown()
         connected = CountDownLatch(1)
         serviceDiscoveryComplete = CountDownLatch(1)
         flushConfirmationQueue()

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/exceptions/FailedToConnectException.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/exceptions/FailedToConnectException.kt
@@ -1,5 +1,3 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.exceptions
 
-open class FailedToConnectException : Exception {
-    constructor(message: String? = null) : super("Failed to connect: ${message ?: ""}")
-}
+open class FailedToConnectException(message: String? = null) : Exception("Failed to connect: ${message ?: ""}")

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/message/MessageIO.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/message/MessageIO.kt
@@ -37,8 +37,8 @@ class MessageIO(
     fun sendMessage(msg: MessagePacket): MessageSendResult {
         val foundRTS = cmdBleIO.flushIncomingQueue()
         if (foundRTS) {
-            val msg = receiveMessage(false)
-            aapsLogger.warn(LTag.PUMPBTCOMM, "sendMessage received message=$msg")
+            val receivedMessage = receiveMessage(false)
+            aapsLogger.warn(LTag.PUMPBTCOMM, "sendMessage received message=$receivedMessage")
             throw IllegalStateException("Received message while trying to send")
         }
         dataBleIO.flushIncomingQueue()

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/scan/DiscoveredInvalidPodException.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/scan/DiscoveredInvalidPodException.kt
@@ -2,6 +2,5 @@ package info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.scan
 
 import android.os.ParcelUuid
 
-class DiscoveredInvalidPodException : Exception {
-    constructor(message: String, serviceUUIds: List<ParcelUuid?>) : super("$message service UUIDs: $serviceUUIds")
-}
+class DiscoveredInvalidPodException(message: String, serviceUUIds: List<ParcelUuid?>) :
+    Exception("$message service UUIDs: $serviceUUIds")

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/session/Connection.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/session/Connection.kt
@@ -64,7 +64,7 @@ class Connection(
 
     fun connect(connectionWaitCond: ConnectionWaitCondition) {
         aapsLogger.debug("Connecting connectionWaitCond=$connectionWaitCond")
-
+        podState.connectionAttempts++
         podState.bluetoothConnectionState = OmnipodDashPodStateManager.BluetoothConnectionState.CONNECTING
         val autoConnect = false
         val gatt = gattConnection

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BasalProgram.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BasalProgram.kt
@@ -15,8 +15,6 @@ class BasalProgram(
 
     fun hasZeroUnitSegments() = segments.any { it.basalRateInHundredthUnitsPerHour == 0 }
 
-    fun isZeroBasal() = segments.sumBy(Segment::basalRateInHundredthUnitsPerHour) == 0
-
     fun rateAt(date: Date): Double {
         val instance = Calendar.getInstance()
         instance.time = date

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepRepetitionType.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepRepetitionType.kt
@@ -8,6 +8,6 @@ enum class BeepRepetitionType(
     XXX(0x01.toByte()), // Used in lump of coal alert, LOW_RESERVOIR
     XXX2(0x03.toByte()), // Used in USER_SET_EXPIRATION
     XXX3(0x05.toByte()), // published system expiration alert
-    XXX4(0x06.toByte()), // Used in imminent pod expiration alert
+    XXX4(0x06.toByte()), // Used in imminent pod expiration alert, suspend in progress
     XXX5(0x08.toByte()); // Lump of coal alert
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepType.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepType.kt
@@ -4,5 +4,6 @@ enum class BeepType(val value: Byte) {
 
     SILENT(0x00.toByte()),
     FOUR_TIMES_BIP_BEEP(0x02.toByte()), // Used in low reservoir alert, user expiration alert, expiration alert, imminent expiration alert, lump of coal alert
+    XXX(0x04.toByte()), // Used during suspend
     LONG_SINGLE_BEEP(0x06.toByte()); // Used in stop delivery command
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/PodConstants.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/PodConstants.kt
@@ -4,6 +4,6 @@ import java.time.Duration
 
 class PodConstants {
     companion object {
-        val MAX_POD_LIFETIME = Duration.ofMinutes(80)
+        val MAX_POD_LIFETIME = Duration.ofHours(80)
     }
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
@@ -41,6 +41,7 @@ interface OmnipodDashPodStateManager {
     val time: ZonedDateTime?
     val timeDrift: java.time.Duration?
     val expiry: ZonedDateTime?
+    var alarmSynced: Boolean
 
     val messageSequenceNumber: Short
     val sequenceNumberOfLastProgrammingCommand: Short?

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
@@ -31,6 +31,8 @@ interface OmnipodDashPodStateManager {
     val isPodRunning: Boolean
     val isPodKaput: Boolean
     var bluetoothConnectionState: BluetoothConnectionState
+    var connectionAttempts: Int
+    var successfulConnections: Int
 
     var timeZone: TimeZone
     val sameTimeZone: Boolean // The TimeZone is the same on the phone and on the pod
@@ -81,6 +83,7 @@ interface OmnipodDashPodStateManager {
     fun updateFromAlarmStatusResponse(response: AlarmStatusResponse)
     fun updateFromPairing(uniqueId: Id, pairResult: PairResult)
     fun reset()
+    fun connectionSuccessRatio(): Float
 
     fun createActiveCommand(
         historyId: String,

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -124,7 +124,19 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     override val sameTimeZone: Boolean
         get() {
             val now = System.currentTimeMillis()
-            return TimeZone.getDefault().getOffset(now) == timeZone.getOffset(now)
+            val currentTimezone = TimeZone.getDefault()
+            val currentOffset = currentTimezone.getOffset(now)
+            val podOffset = timeZone.getOffset(now)
+            logger.debug(
+                LTag.PUMPCOMM,
+                "sameTimeZone currentTimezone=${currentTimezone.getDisplayName(
+                    true,
+                    TimeZone.SHORT
+                )} " +
+                    "currentOffset=$currentOffset " +
+                    "podOffset=$podOffset"
+            )
+            return currentOffset == podOffset
         }
 
     override val bluetoothVersion: SoftwareVersion?
@@ -231,6 +243,13 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
                     .plus(Duration.ofMillis(System.currentTimeMillis() - lastUpdatedSystem))
             }
             return null
+        }
+
+    override var alarmSynced: Boolean
+        get() = podState.alarmSynced
+        set(value) {
+            podState.alarmSynced = value
+            store()
         }
 
     override var bluetoothConnectionState: OmnipodDashPodStateManager.BluetoothConnectionState
@@ -498,8 +517,10 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
                 podState.lastStatusResponseReceived = 0
             }
 
-            CommandSendingFailure, NoActiveCommand ->
+            CommandSendingFailure, NoActiveCommand -> {
                 podState.activeCommand = null
+                podState.lastStatusResponseReceived = 0
+            }
         }
     }
 
@@ -576,7 +597,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     override fun updateFromAlarmStatusResponse(response: AlarmStatusResponse) {
         logger.info(
             LTag.PUMP,
-            "Received AlarmStatusReponse: $response"
+            "Received AlarmStatusResponse: $response"
         )
         podState.deliveryStatus = response.deliveryStatus
         podState.podStatus = response.podStatus
@@ -660,6 +681,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         var eapAkaSequenceNumber: Long = 1
         var bolusPulsesRemaining: Short = 0
         var timeZone: String = "" // TimeZone ID (e.g. "Europe/Amsterdam")
+        var alarmSynced: Boolean = false
 
         var bleVersion: SoftwareVersion? = null
         var firmwareVersion: SoftwareVersion? = null

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -98,6 +98,22 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             }
         }
 
+    override var connectionAttempts: Int
+        @Synchronized
+        get() = podState.connectionAttempts
+        @Synchronized
+        set(value) {
+            podState.connectionAttempts = value
+        }
+
+    override var successfulConnections: Int
+        @Synchronized
+        get() = podState.successfulConnections
+        @Synchronized
+        set(value) {
+            podState.successfulConnections = value
+        }
+
     override var timeZone: TimeZone
         get() = TimeZone.getTimeZone(podState.timeZone)
         set(tz) {
@@ -588,6 +604,14 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         podState.uniqueId = uniqueId.toLong()
     }
 
+    override fun connectionSuccessRatio(): Float {
+        val attempts = connectionAttempts
+        if (attempts == 0) {
+            return 1.0F
+        }
+        return successfulConnections.toFloat() * 100 / attempts.toFloat()
+    }
+
     override fun reset() {
         podState = PodState()
         store()
@@ -625,6 +649,8 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         var lastStatusResponseReceived: Long = 0
         var bluetoothConnectionState: OmnipodDashPodStateManager.BluetoothConnectionState =
             OmnipodDashPodStateManager.BluetoothConnectionState.DISCONNECTED
+        var connectionAttempts = 0
+        var successfulConnections = 0
         var messageSequenceNumber: Short = 0
         var sequenceNumberOfLastProgrammingCommand: Short? = null
         var activationTime: Long? = null

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -218,6 +218,9 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         _binding = null
+        _bluetoothStatusBinding = null
+        _buttonBinding = null
+        _podInfoBinding = null
     }
 
     private fun updateUi() {

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -232,11 +232,11 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
             ?: PLACEHOLDER
         bluetoothStatusBinding.omnipodDashBluetoothStatus.text =
             when (podStateManager.bluetoothConnectionState) {
-                OmnipodDashPodStateManager.BluetoothConnectionState.CONNECTED    ->
+                OmnipodDashPodStateManager.BluetoothConnectionState.CONNECTED ->
                     "{fa-bluetooth}"
                 OmnipodDashPodStateManager.BluetoothConnectionState.DISCONNECTED ->
                     "{fa-bluetooth-b}"
-                OmnipodDashPodStateManager.BluetoothConnectionState.CONNECTING   ->
+                OmnipodDashPodStateManager.BluetoothConnectionState.CONNECTING ->
                     "{fa-bluetooth-b spin}"
             }
 
@@ -250,7 +250,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
                 Color.WHITE
             connectionSuccessPercentage > 60 ->
                 Color.YELLOW
-            else                             ->
+            else ->
                 Color.RED
         }
         bluetoothStatusBinding.omnipodDashBluetoothConnectionQuality.setTextColor(connectionStatsColor)
@@ -308,9 +308,9 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
                 when {
                     !podStateManager.sameTimeZone ->
                         Color.MAGENTA
-                    timeDeviationTooBig           ->
+                    timeDeviationTooBig ->
                         Color.YELLOW
-                    else                          ->
+                    else ->
                         Color.WHITE
                 }
             )
@@ -406,7 +406,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
                     System.currentTimeMillis() -
                         podStateManager.lastUpdatedSystem,
 
-                    )
+                )
             )
             val lastConnectionColor =
                 if (omnipodDashPumpPlugin.isUnreachableAlertTimeoutExceeded(getPumpUnreachableTimeout().toMillis())) {
@@ -455,9 +455,9 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
         val podStatusColor = when {
             !podStateManager.isActivationCompleted || podStateManager.isPodKaput || podStateManager.isSuspended ->
                 Color.RED
-            podStateManager.activeCommand != null                                                               ->
+            podStateManager.activeCommand != null ->
                 Color.YELLOW
-            else                                                                                                ->
+            else ->
                 Color.WHITE
         }
         podInfoBinding.podStatus.setTextColor(podStatusColor)
@@ -552,7 +552,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
     private fun updateRefreshStatusButton() {
         buttonBinding.buttonRefreshStatus.isEnabled =
             podStateManager.isUniqueIdSet &&
-                isQueueEmpty()
+            isQueueEmpty()
     }
 
     private fun updateResumeDeliveryButton() {
@@ -634,15 +634,15 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
         val minutes = duration.toMinutes().toInt()
         val seconds = duration.seconds
         when {
-            seconds < 10           -> {
+            seconds < 10 -> {
                 return resourceHelper.gs(R.string.omnipod_common_moments_ago)
             }
 
-            seconds < 60           -> {
+            seconds < 60 -> {
                 return resourceHelper.gs(R.string.omnipod_common_less_than_a_minute_ago)
             }
 
-            seconds < 60 * 60      -> { // < 1 hour
+            seconds < 60 * 60 -> { // < 1 hour
                 return resourceHelper.gs(
                     R.string.omnipod_common_time_ago,
                     resourceHelper.gq(R.plurals.omnipod_common_minutes, minutes, minutes)
@@ -666,7 +666,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
                 )
             }
 
-            else                   -> {
+            else -> {
                 val days = hours / 24
                 val hoursLeft = hours % 24
                 if (hoursLeft > 0)

--- a/omnipod-dash/src/main/res/layout/omnipod_dash_overview_bluetooth_status.xml
+++ b/omnipod-dash/src/main/res/layout/omnipod_dash_overview_bluetooth_status.xml
@@ -13,7 +13,7 @@
             android:gravity="end"
             android:paddingStart="5dp"
             android:paddingEnd="5dp"
-            android:text="@string/omnipod_dash_overview_bluetooth_status"
+            android:text="@string/omnipod_dash_overview_bluetooth_address"
             android:textSize="14sp" />
 
         <TextView
@@ -51,7 +51,7 @@
             android:gravity="end"
             android:paddingStart="5dp"
             android:paddingEnd="5dp"
-            android:text="@string/omnipod_dash_overview_bluetooth_address"
+            android:text="@string/omnipod_dash_overview_bluetooth_status"
             android:textSize="14sp" />
 
         <TextView
@@ -78,6 +78,83 @@
             tools:ignore="HardcodedText" />
     </LinearLayout>
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.5"
+            android:gravity="end"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:text="@string/omnipod_dash_overview_bluetooth_connection_quality"
+            android:textSize="14sp" />
+
+        <TextView
+            android:layout_width="5dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:gravity="center_horizontal"
+            android:paddingStart="2dp"
+            android:paddingEnd="2dp"
+            android:text=":"
+            android:textSize="14sp"
+            tools:ignore="HardcodedText" />
+
+        <com.joanzapata.iconify.widget.IconTextView
+            android:id="@+id/omnipod_dash_bluetooth_connection_quality"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="start"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:text="{fa-bluetooth-b} "
+            android:textSize="14sp"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1.5"
+            android:gravity="end"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:text="@string/omnipod_dash_overview_delivery_status"
+            android:textSize="14sp" />
+
+        <TextView
+            android:layout_width="5dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="0"
+            android:gravity="center_horizontal"
+            android:paddingStart="2dp"
+            android:paddingEnd="2dp"
+            android:text=":"
+            android:textSize="14sp"
+            tools:ignore="HardcodedText" />
+
+        <com.joanzapata.iconify.widget.IconTextView
+            android:id="@+id/omnipod_dash_delivery_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="start"
+            android:paddingStart="5dp"
+            android:paddingEnd="5dp"
+            android:text="{fa-bluetooth-b} "
+            android:textSize="14sp"
+            tools:ignore="HardcodedText" />
+    </LinearLayout>
     <View
         android:layout_width="fill_parent"
         android:layout_height="2dip"

--- a/omnipod-dash/src/main/res/layout/omnipod_dash_overview_bluetooth_status.xml
+++ b/omnipod-dash/src/main/res/layout/omnipod_dash_overview_bluetooth_status.xml
@@ -79,9 +79,11 @@
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/connectionQuality"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:visibility="gone">
 
         <TextView
             android:layout_width="match_parent"
@@ -112,15 +114,16 @@
             android:gravity="start"
             android:paddingStart="5dp"
             android:paddingEnd="5dp"
-            android:text="{fa-bluetooth-b} "
             android:textSize="14sp"
             tools:ignore="HardcodedText" />
     </LinearLayout>
 
     <LinearLayout
+        android:id="@+id/deliveryStatus"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:visibility="gone">
 
         <TextView
             android:layout_width="match_parent"
@@ -151,7 +154,6 @@
             android:gravity="start"
             android:paddingStart="5dp"
             android:paddingEnd="5dp"
-            android:text="{fa-bluetooth-b} "
             android:textSize="14sp"
             tools:ignore="HardcodedText" />
     </LinearLayout>

--- a/omnipod-dash/src/main/res/values/strings.xml
+++ b/omnipod-dash/src/main/res/values/strings.xml
@@ -21,4 +21,6 @@
 
     <string name="key_omnipod_common_preferences_category_confirmation_beeps" translatable="false">omnipod_common_preferences_category_confirmation</string>
     <string name="key_common_preferences_category_other_settings" translatable="false">common_preferences_category_other</string>
+    <string name="key_omnipod_common_notification_delivery_suspended_sound_enabled">AAPS.Omnipod.notification_delivery_suspended_sound_enabled</string>
+    <string name="omnipod_common_preferences_notification_delivery_suspended_sound_enabled">Sound when delivery suspended notification enabled</string>
 </resources>

--- a/omnipod-dash/src/main/res/values/strings.xml
+++ b/omnipod-dash/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <string name="omnipod_dash_overview_bluetooth_status">Bluetooth Status</string>
     <string name="omnipod_dash_overview_bluetooth_address">Bluetooth Address</string>
     <string name="omnipod_dash_overview_firmware_version_value">Firmware %1$s / Bluetooth %2$s</string>
+    <string name="omnipod_dash_overview_bluetooth_connection_quality">Connection quality</string>
+    <string name="omnipod_dash_overview_delivery_status">Delivery Status</string>
 
     <!-- Omnipod Dash - Pod Activation Wizard -->
     <string name="omnipod_dash_pod_activation_wizard_start_pod_activation_text">Fill a new Pod with enough insulin for 3 days.\n\nListen for two beeps from the Pod during the filling process. These indicate that the minimum amount of 85U has been inserted. Be sure to completely empty the fill syringe, even after hearing the two beeps.\n\nAfter filling the Pod, please press <b>Next</b>.\n\n<b>Note:</b> do not remove the Pod\'s needle cap at this time.</string>

--- a/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
+++ b/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
@@ -93,6 +93,11 @@
             android:key="@string/key_omnipod_common_notification_uncertain_bolus_sound_enabled"
             android:title="@string/omnipod_common_preferences_notification_uncertain_bolus_sound_enabled" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/key_omnipod_common_notification_delivery_suspended_sound_enabled"
+            android:title="@string/omnipod_common_preferences_notification_delivery_suspended_sound_enabled" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Display debugging stats in the overview panel:

 * connection quality: number of successful connections/total connections attempts: success percentage
 * last delivery status

I tried to display those two fields only in enginerring_mode, but I was not able to load `buildHelper.BuildHelper` in the `DashOverviewFragment`