### PR TITLE
suspend sound alert. other fixes

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -147,13 +147,12 @@ class OmnipodDashPumpPlugin @Inject constructor(
             } else {
                 rxBus.send(EventDismissNotification(Notification.OMNIPOD_POD_NOT_ATTACHED))
                 if (podStateManager.isSuspended) {
-                    val notification =
-                        Notification(
-                            Notification.OMNIPOD_POD_SUSPENDED,
-                            "Insulin delivery suspended",
-                            Notification.NORMAL
-                        )
-                    rxBus.send(EventNewNotification(notification))
+                    showNotification(
+                        Notification.OMNIPOD_POD_SUSPENDED,
+                        "Insulin delivery suspended",
+                        Notification.NORMAL,
+                        R.raw.boluserror
+                    )
                 } else {
                     rxBus.send(EventDismissNotification(Notification.OMNIPOD_POD_SUSPENDED))
                     if (!podStateManager.sameTimeZone) {
@@ -1391,6 +1390,8 @@ class OmnipodDashPumpPlugin @Inject constructor(
                 sp.getBoolean(R.string.key_omnipod_common_notification_uncertain_tbr_sound_enabled, true)
             Notification.OMNIPOD_UNCERTAIN_SMB ->
                 sp.getBoolean(R.string.key_omnipod_common_notification_uncertain_smb_sound_enabled, true)
+            Notification.OMNIPOD_POD_SUSPENDED ->
+                sp.getBoolean(R.string.key_omnipod_common_notification_delivery_suspended_sound_enabled, true)
             else -> true
         }
     }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/OmnipodDashPumpPlugin.kt
@@ -328,6 +328,15 @@ class OmnipodDashPumpPlugin @Inject constructor(
                 Notification.URGENT,
                 R.raw.boluserror
             )
+            if (!podStateManager.alarmSynced) {
+                pumpSync.insertAnnouncement(
+                    error = podStateManager.alarmType?.toString() ?: "Unknown pod failure",
+                    pumpId = Random.Default.nextLong(),
+                    pumpType = PumpType.OMNIPOD_DASH,
+                    pumpSerial = serialNumber()
+                )
+                podStateManager.alarmSynced = true
+            }
         }
         Completable.complete()
     }
@@ -1068,7 +1077,8 @@ class OmnipodDashPumpPlugin @Inject constructor(
     private fun deactivatePod(): PumpEnactResult {
         val ret = executeProgrammingCommand(
             historyEntry = history.createRecord(OmnipodCommandType.DEACTIVATE_POD),
-            command = omnipodManager.deactivatePod().ignoreElements()
+            command = omnipodManager.deactivatePod().ignoreElements(),
+            checkNoActiveCommand = false,
         ).doOnComplete {
             rxBus.send(EventDismissNotification(Notification.OMNIPOD_POD_FAULT))
         }.toPumpEnactResult()

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
@@ -412,7 +412,16 @@ class OmnipodDashManagerImpl @Inject constructor(
                     ), // FIXME use activation time
                     BeepType.FOUR_TIMES_BIP_BEEP,
                     BeepRepetitionType.XXX4
-                )
+                ),
+                AlertConfiguration(
+                    AlertType.SUSPEND_IN_PROGRESS,
+                    enabled = true,
+                    durationInMinutes = 15,
+                    autoOff = false,
+                    AlertTrigger.TimerTrigger(15),
+                    BeepType.XXX,
+                    BeepRepetitionType.XXX4
+                ),
             )
             val userExpiryAlertDelay = podLifeLeft.minus(
                 Duration.ofHours(userConfiguredExpirationHours ?: MAX_POD_LIFETIME.toHours() + 1)

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/OmnipodDashManagerImpl.kt
@@ -412,16 +412,7 @@ class OmnipodDashManagerImpl @Inject constructor(
                     ), // FIXME use activation time
                     BeepType.FOUR_TIMES_BIP_BEEP,
                     BeepRepetitionType.XXX4
-                ),
-                AlertConfiguration(
-                    AlertType.SUSPEND_IN_PROGRESS,
-                    enabled = true,
-                    durationInMinutes = 15,
-                    autoOff = false,
-                    AlertTrigger.TimerTrigger(15),
-                    BeepType.XXX,
-                    BeepRepetitionType.XXX4
-                ),
+                )
             )
             val userExpiryAlertDelay = podLifeLeft.minus(
                 Duration.ofHours(userConfiguredExpirationHours ?: MAX_POD_LIFETIME.toHours() + 1)

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/exceptions/FailedToConnectException.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/exceptions/FailedToConnectException.kt
@@ -1,5 +1,3 @@
 package info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.exceptions
 
-open class FailedToConnectException : Exception {
-    constructor(message: String? = null) : super("Failed to connect: ${message ?: ""}")
-}
+open class FailedToConnectException(message: String? = null) : Exception("Failed to connect: ${message ?: ""}")

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/scan/DiscoveredInvalidPodException.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/scan/DiscoveredInvalidPodException.kt
@@ -2,6 +2,5 @@ package info.nightscout.androidaps.plugins.pump.omnipod.dash.driver.comm.scan
 
 import android.os.ParcelUuid
 
-class DiscoveredInvalidPodException : Exception {
-    constructor(message: String, serviceUUIds: List<ParcelUuid?>) : super("$message service UUIDs: $serviceUUIds")
-}
+class DiscoveredInvalidPodException(message: String, serviceUUIds: List<ParcelUuid?>) :
+    Exception("$message service UUIDs: $serviceUUIds")

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepRepetitionType.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepRepetitionType.kt
@@ -8,6 +8,6 @@ enum class BeepRepetitionType(
     XXX(0x01.toByte()), // Used in lump of coal alert, LOW_RESERVOIR
     XXX2(0x03.toByte()), // Used in USER_SET_EXPIRATION
     XXX3(0x05.toByte()), // published system expiration alert
-    XXX4(0x06.toByte()), // Used in imminent pod expiration alert
+    XXX4(0x06.toByte()), // Used in imminent pod expiration alert, suspend in progress
     XXX5(0x08.toByte()); // Lump of coal alert
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepType.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepType.kt
@@ -4,5 +4,6 @@ enum class BeepType(val value: Byte) {
 
     SILENT(0x00.toByte()),
     FOUR_TIMES_BIP_BEEP(0x02.toByte()), // Used in low reservoir alert, user expiration alert, expiration alert, imminent expiration alert, lump of coal alert
+    XXX(0x04.toByte()), // Used during suspend
     LONG_SINGLE_BEEP(0x06.toByte()); // Used in stop delivery command
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepType.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepType.kt
@@ -4,6 +4,6 @@ enum class BeepType(val value: Byte) {
 
     SILENT(0x00.toByte()),
     FOUR_TIMES_BIP_BEEP(0x02.toByte()), // Used in low reservoir alert, user expiration alert, expiration alert, imminent expiration alert, lump of coal alert
-    XXX(0x04.toByte()),  // Used during suspend
+    XXX(0x04.toByte()), // Used during suspend
     LONG_SINGLE_BEEP(0x06.toByte()); // Used in stop delivery command
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepType.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/BeepType.kt
@@ -4,6 +4,6 @@ enum class BeepType(val value: Byte) {
 
     SILENT(0x00.toByte()),
     FOUR_TIMES_BIP_BEEP(0x02.toByte()), // Used in low reservoir alert, user expiration alert, expiration alert, imminent expiration alert, lump of coal alert
-    XXX(0x04.toByte()), // Used during suspend
+    XXX(0x04.toByte()),  // Used during suspend
     LONG_SINGLE_BEEP(0x06.toByte()); // Used in stop delivery command
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/PodConstants.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/definition/PodConstants.kt
@@ -4,6 +4,6 @@ import java.time.Duration
 
 class PodConstants {
     companion object {
-        val MAX_POD_LIFETIME = Duration.ofMinutes(80)
+        val MAX_POD_LIFETIME = Duration.ofHours(80)
     }
 }

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManager.kt
@@ -41,6 +41,7 @@ interface OmnipodDashPodStateManager {
     val time: ZonedDateTime?
     val timeDrift: java.time.Duration?
     val expiry: ZonedDateTime?
+    var alarmSynced: Boolean
 
     val messageSequenceNumber: Short
     val sequenceNumberOfLastProgrammingCommand: Short?

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -117,7 +117,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     override var timeZone: TimeZone
         get() = TimeZone.getTimeZone(podState.timeZone)
         set(tz) {
-            podState.timeZone = tz.getDisplayName(true, TimeZone.SHORT)
+            podState.timeZone = tz.getDisplayName(false, TimeZone.SHORT)
             store()
         }
 

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -124,7 +124,10 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     override val sameTimeZone: Boolean
         get() {
             val now = System.currentTimeMillis()
-            return TimeZone.getDefault().getOffset(now) == timeZone.getOffset(now)
+            val currentOffset = TimeZone.getDefault().getOffset(now)
+            val podOffset = timeZone.getOffset(now)
+            logger.debug(LTag.PUMPCOMM, "sameTimeZone currentOffset=$currentOffset podOffset=$podOffset")
+            return currentOffset == podOffset
         }
 
     override val bluetoothVersion: SoftwareVersion?

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -124,9 +124,18 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     override val sameTimeZone: Boolean
         get() {
             val now = System.currentTimeMillis()
-            val currentOffset = TimeZone.getDefault().getOffset(now)
+            val currentTimezone = TimeZone.getDefault()
+            val currentOffset = currentTimezone.getOffset(now)
             val podOffset = timeZone.getOffset(now)
-            logger.debug(LTag.PUMPCOMM, "sameTimeZone currentOffset=$currentOffset podOffset=$podOffset")
+            logger.debug(
+                LTag.PUMPCOMM,
+                "sameTimeZone currentTimezone=${currentTimezone.getDisplayName(
+                    true,
+                    TimeZone.SHORT
+                )} " +
+                    "currentOffset=$currentOffset " +
+                    "podOffset=$podOffset"
+            )
             return currentOffset == podOffset
         }
 
@@ -588,7 +597,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     override fun updateFromAlarmStatusResponse(response: AlarmStatusResponse) {
         logger.info(
             LTag.PUMP,
-            "Received AlarmStatusReponse: $response"
+            "Received AlarmStatusResponse: $response"
         )
         podState.deliveryStatus = response.deliveryStatus
         podState.podStatus = response.podStatus

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -233,6 +233,13 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
             return null
         }
 
+    override var alarmSynced: Boolean
+        get() = podState.alarmSynced
+        set(value) {
+            podState.alarmSynced = value
+            store()
+        }
+
     override var bluetoothConnectionState: OmnipodDashPodStateManager.BluetoothConnectionState
         @Synchronized
         get() = podState.bluetoothConnectionState
@@ -498,8 +505,10 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
                 podState.lastStatusResponseReceived = 0
             }
 
-            CommandSendingFailure, NoActiveCommand ->
+            CommandSendingFailure, NoActiveCommand -> {
                 podState.activeCommand = null
+                podState.lastStatusResponseReceived = 0
+            }
         }
     }
 
@@ -660,6 +669,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
         var eapAkaSequenceNumber: Long = 1
         var bolusPulsesRemaining: Short = 0
         var timeZone: String = "" // TimeZone ID (e.g. "Europe/Amsterdam")
+        var alarmSynced: Boolean = false
 
         var bleVersion: SoftwareVersion? = null
         var firmwareVersion: SoftwareVersion? = null

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -117,7 +117,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     override var timeZone: TimeZone
         get() = TimeZone.getTimeZone(podState.timeZone)
         set(tz) {
-            podState.timeZone = tz.getDisplayName(false, TimeZone.SHORT)
+            podState.timeZone = tz.getDisplayName(true, TimeZone.SHORT)
             store()
         }
 

--- a/omnipod-dash/src/main/res/values/strings.xml
+++ b/omnipod-dash/src/main/res/values/strings.xml
@@ -21,4 +21,6 @@
 
     <string name="key_omnipod_common_preferences_category_confirmation_beeps" translatable="false">omnipod_common_preferences_category_confirmation</string>
     <string name="key_common_preferences_category_other_settings" translatable="false">common_preferences_category_other</string>
+    <string name="key_omnipod_common_notification_delivery_suspended_sound_enabled">AAPS.Omnipod.notification_delivery_suspended_sound_enabled</string>
+    <string name="omnipod_common_preferences_notification_delivery_suspended_sound_enabled">Sound when delivery suspended notification enabled</string>
 </resources>

--- a/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
+++ b/omnipod-dash/src/main/res/xml/omnipod_dash_preferences.xml
@@ -93,6 +93,11 @@
             android:key="@string/key_omnipod_common_notification_uncertain_bolus_sound_enabled"
             android:title="@string/omnipod_common_preferences_notification_uncertain_bolus_sound_enabled" />
 
+        <SwitchPreference
+            android:defaultValue="true"
+            android:key="@string/key_omnipod_common_notification_delivery_suspended_sound_enabled"
+            android:title="@string/omnipod_common_preferences_notification_delivery_suspended_sound_enabled" />
+
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
- add option to alert when delivery is suspended
- insertAnnouncement on pod alarm

Bugfixes:
- fix a a bug that could make old(>3 days) pod not able to be deactivated(by setting `lastStatusResponseReceived` to 0 `onStart`)
- MAX_POD_LIFETIME is in hours and not minutes: this is used in alerts