### PR TITLE
Fixed connection quality display

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -628,9 +628,9 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
     override fun connectionSuccessRatio(): Float {
         val attempts = connectionAttempts
         if (attempts == 0) {
-            return 1.0F
+            return 0.0F
         }
-        return successfulConnections.toFloat() * 100 / attempts.toFloat()
+        return successfulConnections.toFloat() / attempts.toFloat()
     }
 
     override fun reset() {

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/ui/OmnipodDashOverviewFragment.kt
@@ -244,7 +244,7 @@ class OmnipodDashOverviewFragment : DaggerFragment() {
             }
 
         val connectionSuccessPercentage = podStateManager.connectionSuccessRatio() * 100
-        val successPercentageString = String.format("%.2f %%", podStateManager.connectionSuccessRatio())
+        val successPercentageString = String.format("%.2f %%", connectionSuccessPercentage)
         val quality =
             "${podStateManager.successfulConnections}/${podStateManager.connectionAttempts} :: $successPercentageString"
         bluetoothStatusBinding.omnipodDashBluetoothConnectionQuality.text = quality


### PR DESCRIPTION
Fix for issue#83
Repaired slight mixup on quilityRatio (0..1) and percentage (0..100)
Now shows correctly "0/0 :: 0%" at Pod start
