### PR TITLE
Pod expiry datetime drifting until next refresh or connection (issue#92)

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/pod/state/OmnipodDashPodStateManagerImpl.kt
@@ -240,7 +240,7 @@ class OmnipodDashPodStateManagerImpl @Inject constructor(
                 return ZonedDateTime.now()
                     .plusHours(podLifeInHours.toLong())
                     .minusMinutes(minutesSinceActivation.toLong())
-                    .plus(Duration.ofMillis(System.currentTimeMillis() - lastUpdatedSystem))
+                    .minus(Duration.ofMillis(System.currentTimeMillis() - lastUpdatedSystem))
             }
             return null
         }


### PR DESCRIPTION
Fixing "Pod expires" drifting on DASH overview.
