### PR TITLE
bugfix: ALARM_ILLEGAL_PUMP_STATE

### DIFF
--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/message/MessageIO.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/message/MessageIO.kt
@@ -177,10 +177,10 @@ class MessageIO(
             }
 
             BleCommandSuccess -> {
-                if (index != packets.size)
-                    MessageSendErrorSending("Received SUCCESS before sending all the data. $index")
-                else
+                if (index == packets.size-1)
                     MessageSendSuccess
+                else
+                    MessageSendErrorSending("Received SUCCESS before sending all the data. $index")
             }
 
             else ->

--- a/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/session/Session.kt
+++ b/omnipod-dash/src/main/java/info/nightscout/androidaps/plugins/pump/omnipod/dash/driver/comm/session/Session.kt
@@ -37,7 +37,6 @@ class Session(
         aapsLogger.debug(LTag.PUMPBTCOMM, "Sending command: ${cmd.encoded.toHex()} in packet $cmd")
 
         val msg = getCmdMessage(cmd)
-        var possiblyUnconfirmedCommand = false
         for (i in 0..MAX_TRIES) {
             aapsLogger.debug(LTag.PUMPBTCOMM, "Sending command(wrapped): ${msg.payload.toHex()}")
 
@@ -46,8 +45,8 @@ class Session(
                     return CommandSendSuccess
 
                 is MessageSendErrorConfirming -> {
-                    possiblyUnconfirmedCommand = true
                     aapsLogger.debug(LTag.PUMPBTCOMM, "Error confirming command: $sendResult")
+                    return CommandSendErrorConfirming(sendResult.msg)
                 }
 
                 is MessageSendErrorSending ->
@@ -55,11 +54,8 @@ class Session(
             }
         }
 
-        val errMsg = "Maximum number of tries reached. Could not send command\""
-        return if (possiblyUnconfirmedCommand)
-            CommandSendErrorConfirming(errMsg)
-        else
-            CommandSendErrorSending(errMsg)
+        val errMsg = "Maximum number of tries reached. Could not send command"
+        return CommandSendErrorSending(errMsg)
     }
 
     @Suppress("ReturnCount")


### PR DESCRIPTION
bugfix: the index of the last packet is `packets.size-1`, not `packets.size`. 

Another change: do not retry to send unconfirmed commands: from what I saw in logs, if the command was confirmed then the pod is in a state where it sends the response, and not expecting a retry.

This should fix https://github.com/0pen-dash/AndroidAPS/issues/109 and https://github.com/0pen-dash/AndroidAPS/issues/114
